### PR TITLE
SEO & accessibility improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@aleph-sdk/client": "^1.4.5",
-        "@mux/mux-player-react": "^3.4.0",
+        "@mux/mux-player-react": "^3.13.0",
         "@radix-ui/react-accordion": "^1.2.11",
         "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-navigation-menu": "^1.2.13",
@@ -2007,26 +2007,35 @@
         "node": ">=10"
       }
     },
-    "node_modules/@mux/mux-player": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@mux/mux-player/-/mux-player-3.4.0.tgz",
-      "integrity": "sha512-+EK0w+Uw9RPod7VKgMojnUpyE3uK6C37+hwAyuL297wm5aHxsIevWdQMdUOJonsJpQ0MfjnZXMzqLOTEjTgXHQ==",
+    "node_modules/@mux/mux-data-google-ima": {
+      "version": "0.3.17",
+      "resolved": "https://registry.npmjs.org/@mux/mux-data-google-ima/-/mux-data-google-ima-0.3.17.tgz",
+      "integrity": "sha512-4wpH6dYybyZhqLn9qGn/+67Z8MZnQRAdqTFEEZw2bx61M9q01uPYYHxd8qwOnYtUGEeafsdTwVHVxKHGD3oc1A==",
       "license": "MIT",
       "dependencies": {
-        "@mux/mux-video": "0.25.2",
-        "@mux/playback-core": "0.29.0",
-        "media-chrome": "~4.9.1",
-        "player.style": "^0.1.8"
+        "mux-embed": "5.18.1"
+      }
+    },
+    "node_modules/@mux/mux-player": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@mux/mux-player/-/mux-player-3.13.0.tgz",
+      "integrity": "sha512-vh4CIMahUa29gys+mlfsOFKYKAKXxE07jSWk9WZxkdpGBW1fKfCQXlNxBoAIQlPa9Uk4MZuM3HVgqdW6aTuaZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@mux/mux-video": "0.31.0",
+        "@mux/playback-core": "0.35.0",
+        "media-chrome": "~4.19.0",
+        "player.style": "^0.3.0"
       }
     },
     "node_modules/@mux/mux-player-react": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@mux/mux-player-react/-/mux-player-react-3.4.0.tgz",
-      "integrity": "sha512-IPzxyETJkaZTqyRew3j2+BJNePHWXnzqGWl8FRLfcVe5WHMbPk6EwsIGk2/ILUqy0HovrxO3ydXrE7VJRaYOug==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@mux/mux-player-react/-/mux-player-react-3.13.0.tgz",
+      "integrity": "sha512-7IkImo1H3rUYeuWHI/L0L7sGUqBvZCvptx3+4igc+P/V3WgqNFjOyQlcyxzxgXNtNNhGmkn5NaF3TU9DPbOmAQ==",
       "license": "MIT",
       "dependencies": {
-        "@mux/mux-player": "3.4.0",
-        "@mux/playback-core": "0.29.0",
+        "@mux/mux-player": "3.13.0",
+        "@mux/playback-core": "0.35.0",
         "prop-types": "^15.8.1"
       },
       "peerDependencies": {
@@ -2044,25 +2053,26 @@
       }
     },
     "node_modules/@mux/mux-video": {
-      "version": "0.25.2",
-      "resolved": "https://registry.npmjs.org/@mux/mux-video/-/mux-video-0.25.2.tgz",
-      "integrity": "sha512-mP7WTyAcoZemf298OhaDLuTvOZq8wGCtuVMwBO34BR6Lol8JBg0nqb9O3QHfGLIAV+yaTJcODeZk76Ml/jYbDw==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/@mux/mux-video/-/mux-video-0.31.0.tgz",
+      "integrity": "sha512-DvO2GynIJhPDc0LMuWvC144lCF+E07NI+chrg/vcRQlCf2fPdNNqCSMoaRdWu2S2v/Orsc85giT9K6GRbjbzgA==",
       "license": "MIT",
       "dependencies": {
-        "@mux/playback-core": "0.29.0",
-        "castable-video": "~1.1.7",
-        "custom-media-element": "~1.4.2",
-        "media-tracks": "~0.3.3"
+        "@mux/mux-data-google-ima": "^0.3.4",
+        "@mux/playback-core": "0.35.0",
+        "castable-video": "~1.1.13",
+        "custom-media-element": "~1.4.6",
+        "media-tracks": "~0.3.5"
       }
     },
     "node_modules/@mux/playback-core": {
-      "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@mux/playback-core/-/playback-core-0.29.0.tgz",
-      "integrity": "sha512-Bd12B1pW/1o6+Z+FXIs0ejlS5ejzApCX4sTd/Jn/bqxmOYA2tR7HjTq856hSGd441WtJQmfm/aNT5oDK9UyTSA==",
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@mux/playback-core/-/playback-core-0.35.0.tgz",
+      "integrity": "sha512-7Zi1EJ9sQNIUlQVBjJCXV0CB+rUVEsU3vNRElRV4xnD7dbpoioIAhe1SjZNBifjnK5aBKLDwQHypbnL3Cw3a5A==",
       "license": "MIT",
       "dependencies": {
-        "hls.js": "~1.5.19",
-        "mux-embed": "^5.8.3"
+        "hls.js": "~1.6.15",
+        "mux-embed": "^5.16.1"
       }
     },
     "node_modules/@noble/curves": {
@@ -5003,12 +5013,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/@vercel/edge": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@vercel/edge/-/edge-1.2.1.tgz",
-      "integrity": "sha512-1++yncEyIAi68D3UEOlytYb1IUcIulMWdoSzX2h9LuSeeyR7JtaIgR8DcTQ6+DmYOQn+5MCh6LY+UmK6QBByNA==",
-      "license": "Apache-2.0"
-    },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.4.1.tgz",
@@ -5820,18 +5824,18 @@
       "license": "CC-BY-4.0"
     },
     "node_modules/castable-video": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/castable-video/-/castable-video-1.1.8.tgz",
-      "integrity": "sha512-86xTxbVoIIX0gnorM10pl7ScdELdqPTMInvzSjQM/YbMxq7ml7OosCMYbZi0O4bZwgsN3Dq75o+XLb0q6dGtIA==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/castable-video/-/castable-video-1.1.16.tgz",
+      "integrity": "sha512-wBhe2dZu2afhewL3EaGgVYTyDsa9HvNhY98clMZkNzDrLelOValSrTaoMos9YX7PPBCrgpd1j6YmNyyI2Vbq3w==",
       "license": "MIT",
       "dependencies": {
-        "custom-media-element": "~1.4.3"
+        "custom-media-element": "~1.4.6"
       }
     },
     "node_modules/ce-la-react": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/ce-la-react/-/ce-la-react-0.1.3.tgz",
-      "integrity": "sha512-zZwEEJv9XukeEGbswQXObaDJjYAufOIilSnDg4BWCpKNEYN84H9fpaB+wl+rYKWOIH4wBBPbLnOxKvDIwsL/JQ==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/ce-la-react/-/ce-la-react-0.3.2.tgz",
+      "integrity": "sha512-QJ6k4lOD/btI08xG8jBPxRCGXvCnusGGkTsiXk0u3NqUu/W+BXRnFD4PYjwtqh8AWmGa5LDbGk0fLQsqr0nSMA==",
       "license": "BSD-3-Clause",
       "peerDependencies": {
         "react": ">=17.0.0"
@@ -6130,9 +6134,9 @@
       "license": "MIT"
     },
     "node_modules/custom-media-element": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/custom-media-element/-/custom-media-element-1.4.3.tgz",
-      "integrity": "sha512-6DAQAC9VfpdUEc684Kr1Uvw+49vKUY3+hAQcBrqMNL577PeA8eM8YgpOmbySoTZ517EIqSVFrXH2nu8gqFJS4g==",
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/custom-media-element/-/custom-media-element-1.4.6.tgz",
+      "integrity": "sha512-/HRYqJOa1ob5ik4q7FIJVYxTJCFs/FL3+cQPAJjUf2uiqrDEzbTgB315gQ2rG8oK3w094W9m5tcB8S5Qah+caA==",
       "license": "MIT"
     },
     "node_modules/data-view-buffer": {
@@ -7516,9 +7520,9 @@
       }
     },
     "node_modules/hls.js": {
-      "version": "1.5.20",
-      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.5.20.tgz",
-      "integrity": "sha512-uu0VXUK52JhihhnN/MVVo1lvqNNuhoxkonqgO3IpjvQiGpJBdIXMGkofjQb/j9zvV7a1SW8U9g1FslWx/1HOiQ==",
+      "version": "1.6.16",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.6.16.tgz",
+      "integrity": "sha512-VSIRpLfRwlAAdGL4wiTucx2ScRipo0ed1FBatWkyt832jC4CReKstga6yIhYVwGu9LOBjuX9wzmRMeQdBJtzEA==",
       "license": "Apache-2.0"
     },
     "node_modules/hmac-drbg": {
@@ -8566,19 +8570,18 @@
       }
     },
     "node_modules/media-chrome": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/media-chrome/-/media-chrome-4.9.1.tgz",
-      "integrity": "sha512-lOdYhWVCYg0Az2VnVKPoE/eUflVrNyauHg8cLa/ibsBg4CB6RhRQBTdQsq36NuiSNSQU0B3vtmaTNFTUFT12RA==",
+      "version": "4.19.0",
+      "resolved": "https://registry.npmjs.org/media-chrome/-/media-chrome-4.19.0.tgz",
+      "integrity": "sha512-HWhDTwts+BSbdPkkB1VsJXp5kvL0IxY7xFT5tBwliM2+89kTPVTnHnev+9it2f9PweANjT/C8/C/S0PW9oyZbA==",
       "license": "MIT",
       "dependencies": {
-        "@vercel/edge": "^1.2.1",
-        "ce-la-react": "^0.1.3"
+        "ce-la-react": "^0.3.2"
       }
     },
     "node_modules/media-tracks": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/media-tracks/-/media-tracks-0.3.3.tgz",
-      "integrity": "sha512-9P2FuUHnZZ3iji+2RQk7Zkh5AmZTnOG5fODACnjhCVveX1McY3jmCRHofIEI+yTBqplz7LXy48c7fQ3Uigp88w==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/media-tracks/-/media-tracks-0.3.5.tgz",
+      "integrity": "sha512-l54rkKXlLBt3ob3zOLWHcnjvwUmX5bNEZ70igyapOZZC9imzqBmq1oz8p2roiV04KhjblFIi2hetLPF1oYVLRA==",
       "license": "MIT"
     },
     "node_modules/micro-ftch": {
@@ -8685,9 +8688,9 @@
       "license": "MIT"
     },
     "node_modules/mux-embed": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/mux-embed/-/mux-embed-5.9.0.tgz",
-      "integrity": "sha512-wmunL3uoPhma/tWy8PrDPZkvJpXvSFBwbD3KkC4PG8Ztjfb1X3hRJwGUAQyRz7z99b/ovLm2UTTitrkvStjH4w==",
+      "version": "5.18.1",
+      "resolved": "https://registry.npmjs.org/mux-embed/-/mux-embed-5.18.1.tgz",
+      "integrity": "sha512-ePsHjiEKY+FgrSBiMmaF+LOtTQSSBWv/1zqpREQFN96JE93xlsArT/MEi30yKOE06MgjOlL70YI750molu3y7g==",
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -9124,9 +9127,9 @@
       }
     },
     "node_modules/player.style": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/player.style/-/player.style-0.1.8.tgz",
-      "integrity": "sha512-r/k2gX1IS3tIH/MQJsXQ0pt54s0NqQ70jSePQSKBlu1Rwf/qqdFUmSKACL10ebS48B0VioclwbvKzBnqgb52Tw==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/player.style/-/player.style-0.3.4.tgz",
+      "integrity": "sha512-5O9bkbq0APQIkhptyZwp0gUgheCeImGPFo4hvPF2M5xBmgsUYzsUPHCfMye2xyeRE1zvQBKtziaC3jPgnHE1tw==",
       "license": "MIT",
       "workspaces": [
         ".",
@@ -9136,7 +9139,7 @@
         "themes/*"
       ],
       "dependencies": {
-        "media-chrome": "~4.9.0"
+        "media-chrome": "~4.19.0"
       }
     },
     "node_modules/pony-cause": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@aleph-sdk/client": "^1.4.5",
-    "@mux/mux-player-react": "^3.4.0",
+    "@mux/mux-player-react": "^3.13.0",
     "@radix-ui/react-accordion": "^1.2.11",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-navigation-menu": "^1.2.13",

--- a/src/components/FooterSection.tsx
+++ b/src/components/FooterSection.tsx
@@ -128,23 +128,24 @@ export function FooterSection() {
 
 						{/* Social Media Icons */}
 						<div className="flex justify-center gap-6 pt-4">
-							<a href="https://t.me/libertai" target="_blank" rel="noopener noreferrer" className="hover:text-white transition-colors">
+							<a href="https://t.me/libertai" target="_blank" rel="noopener noreferrer" aria-label="LibertAI on Telegram" className="hover:text-white transition-colors">
 								<FaTelegram size={24} />
 							</a>
-							<a href="https://x.com/Libertai_DAI" target="_blank" rel="noopener noreferrer" className="hover:text-white transition-colors">
+							<a href="https://x.com/Libertai_DAI" target="_blank" rel="noopener noreferrer" aria-label="LibertAI on X" className="hover:text-white transition-colors">
 								<FaXTwitter size={24} />
 							</a>
-							<a href="https://github.com/libertai" target="_blank" rel="noopener noreferrer" className="hover:text-white transition-colors">
+							<a href="https://github.com/libertai" target="_blank" rel="noopener noreferrer" aria-label="LibertAI on GitHub" className="hover:text-white transition-colors">
 								<FaGithub size={24} />
 							</a>
 							<a
 								href="https://linkedin.com/company/libertai"
 								target="_blank" rel="noopener noreferrer"
+								aria-label="LibertAI on LinkedIn"
 								className="hover:text-white transition-colors"
 							>
 								<FaLinkedin size={24} />
 							</a>
-							<a href="https://discord.gg/alephcloud" target="_blank" rel="noopener noreferrer" className="hover:text-white transition-colors">
+							<a href="https://discord.gg/alephcloud" target="_blank" rel="noopener noreferrer" aria-label="LibertAI on Discord" className="hover:text-white transition-colors">
 								<FaDiscord size={24} />
 							</a>
 						</div>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -145,7 +145,7 @@ export function Navbar() {
 						{/* Mobile Menu Sheet */}
 						<Sheet open={isSheetOpen} onOpenChange={setIsSheetOpen}>
 							<SheetTrigger asChild>
-								<Button variant="ghost" size="icon" className="text-white">
+								<Button variant="ghost" size="icon" className="text-white" aria-label="Open menu">
 									<Menu className="h-5 w-5" />
 								</Button>
 							</SheetTrigger>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -119,13 +119,13 @@ export function Navbar() {
 
 					{/* Right side: CTA Button (Desktop only) */}
 					<div className="hidden md:flex">
-						<a href={ctaLink} target="_blank" rel="noopener noreferrer">
+						<a href={ctaLink} target="_blank" rel="noopener noreferrer" aria-label={ctaText}>
 							<Button variant="glass" size="pill" className="hidden lg:flex">
 								<span>{ctaText}</span>
 								<ExternalLink className="w-4 h-4" />
 							</Button>
 						</a>
-						<a href={ctaLink} target="_blank" rel="noopener noreferrer">
+						<a href={ctaLink} target="_blank" rel="noopener noreferrer" aria-label={ctaText}>
 							<Button variant="glass" size="pill-sm" className="lg:hidden">
 								<span>{ctaText}</span>
 								<ExternalLink className="w-4 h-4" />

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,9 @@ import { defineConfig } from "vite";
 // https://vite.dev/config/
 export default defineConfig({
 	plugins: [TanStackRouterVite({ target: "react", autoCodeSplitting: true }), react(), tailwindcss(), nodePolyfills()],
+	build: {
+		sourcemap: true,
+	},
 	resolve: {
 		alias: {
 			"@": path.resolve(__dirname, "./src"),


### PR DESCRIPTION
## Summary
Lighthouse-driven SEO/accessibility fixes.

- **Source maps in production** — `build.sourcemap: true` in `vite.config.ts`, resolving Lighthouse "Missing source maps for large first-party JavaScript".
- **Accessible names for icon-only controls** — `aria-label` on the mobile menu hamburger button and all 5 footer social links (Telegram, X, GitHub, LinkedIn, Discord).
- **Desktop CTA links** — `aria-label` on both desktop CTA anchors, so the link keeps a discernible name even when its child button is `display:none` at a given breakpoint.
- **Mux player dialog a11y** — bumped `@mux/mux-player-react` 3.4.0 → 3.13.0 (pulls `media-chrome` 4.9.1 → 4.19.0), which sets `aria-label` on the `media-error-dialog` (`role="dialog"`), giving it an accessible name.

## Notes / out of scope
- **Cache lifetimes** ("Use efficient cache lifetimes") is a server-side header change on `/var/www`, not a code change — deferred (and moot once assets move to IPFS).
- **Mux console MediaError** in audits is an audit-environment artifact: the stream is H.264/AAC and headless Chromium lacks proprietary codecs, so it can't decode. Real Chrome/Edge/Safari play fine. Not fixed here.

## Test plan
- [x] `npm run build` passes; `.js.map` files emitted alongside bundles.
- [ ] Re-run Lighthouse against the deployed build to confirm the four audits clear.