### PR TITLE
ci: Aleph hosting action v2 + dedicated production deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,30 @@
+name: Production deployment
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    name: "Deploy to production"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+          cache-dependency-path: 'package-lock.json'
+      - name: Install dependencies
+        run: npm ci --force
+      - name: Build project
+        run: npm run build
+
+      - name: Deploy with Aleph
+        uses: aleph-im/web3-hosting-action@v2.0.0-rc1
+        with:
+          path: 'dist'
+          private-key: ${{ secrets.ALEPH_PRIVATE_KEY }}
+          owner-address: ${{ vars.ALEPH_OWNER_ADDRESS }}
+          domain: libertai.io
+          retention_days: 1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,13 +42,3 @@ jobs:
         uses: aleph-im/web3-hosting-action@v2.0.0-rc1
         with:
           path: 'dist'
-
-      - name: Deploy on Aleph
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-        uses: aleph-im/web3-hosting-action@v2.0.0-rc1
-        with:
-          path: 'dist'
-          private-key: ${{ secrets.ALEPH_PRIVATE_KEY }}
-          owner-address: ${{ vars.ALEPH_OWNER_ADDRESS }}
-          domain: libertai.io
-          retention_days: 30

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,6 +39,16 @@ jobs:
 
       - name: Deploy preview on Aleph
         if: ${{ github.event_name == 'pull_request' }}
-        uses: aleph-im/web3-hosting-action@v1.1.2
+        uses: aleph-im/web3-hosting-action@v2.0.0-rc1
         with:
           path: 'dist'
+
+      - name: Deploy on Aleph
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        uses: aleph-im/web3-hosting-action@v2.0.0-rc1
+        with:
+          path: 'dist'
+          private-key: ${{ secrets.ALEPH_PRIVATE_KEY }}
+          owner-address: ${{ vars.ALEPH_OWNER_ADDRESS }}
+          domain: libertai.io
+          retention_days: 30


### PR DESCRIPTION
Bumps `aleph-im/web3-hosting-action` to `v2.0.0-rc1` and restructures deployment to match the convention used by other LibertAI sites (e.g. libertai-console).

## Changes
- **`main.yml`** (push + PR): PR previews now use the v2 action (free, anonymous, garbage-collected ~24h). ✅ verified working on this PR.
- **`deploy.yml`** (new, `workflow_dispatch`): manual production deploy to Aleph with delegated billing
  - `owner-address`: `${{ vars.ALEPH_OWNER_ADDRESS }}` — credits billed to the owner wallet
  - `private-key`: `${{ secrets.ALEPH_PRIVATE_KEY }}` — low-privilege CI signing key
  - `domain: libertai.io`, `retention_days: 1`

## Production deploy prerequisites (repo settings)
Secret `ALEPH_PRIVATE_KEY`, variable `ALEPH_OWNER_ADDRESS`, and the owner→CI `aleph authorization add`.

⚠️ **DNS cutover is separate**: running the deploy writes the `libertai.io` domain entry to the Aleph aggregate but does **not** move traffic (still on Vercel). Apex switch on Gandi: replace `@` A/AAAA with an **ALIAS** `@` → `ipfs.public.aleph.sh`, add CNAME `_dnslink` → `_dnslink.libertai.io.static.public.aleph.sh` and TXT `_control` → owner address.