### PR TITLE
ci: pin Aleph hosting action to v2.0.0

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
         run: npm run build
 
       - name: Deploy with Aleph
-        uses: aleph-im/web3-hosting-action@v2.0.0-rc1
+        uses: aleph-im/web3-hosting-action@v2.0.0
         with:
           path: 'dist'
           private-key: ${{ secrets.ALEPH_PRIVATE_KEY }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,6 +39,6 @@ jobs:
 
       - name: Deploy preview on Aleph
         if: ${{ github.event_name == 'pull_request' }}
-        uses: aleph-im/web3-hosting-action@v2.0.0-rc1
+        uses: aleph-im/web3-hosting-action@v2.0.0
         with:
           path: 'dist'


### PR DESCRIPTION
Bumps both workflows from the `v2.0.0-rc1` pre-release to the released **v2.0.0** tag.

- `main.yml` — PR preview step
- `deploy.yml` — production deploy step (takes effect on `main` after merge)

No behavior change: `v2.0.0` is the same code as `v2.0.0-rc1`, just the proper release tag. The preview run on this PR exercises the released tag.